### PR TITLE
docs: explain transparent hero image backgrounds

### DIFF
--- a/content/customisation/hero-section.md
+++ b/content/customisation/hero-section.md
@@ -7,6 +7,7 @@ date: 2026-01-16T08:00:00.000+0700
 * [Use the images front matter array](#use-the-images-front-matter-array)
 * [Featured image as Page Resources](#featured-image-as-page-resources)
 * [Other hero settings](#other-hero-settings)
+* [Set a background color behind transparent hero images](#set-a-background-color-behind-transparent-hero-images)
 
 ## Change the hero background
 
@@ -41,3 +42,28 @@ example: `featured_image_class = "cover bg-center"` or `featured_image_class = "
 The default cover backdrop for the featured image is `bg-black-60`, but can be changed using the `cover_dimming_class`.  Choose a color dimming class for the page or site header from any on the [Tachyons](https://tachyons.io/docs/themes/skins/) library site, preface it with "bg-" and add the value such as "-X0" where X is in [1,9]
 
 example: `cover_dimming_class = "bg-black-20"` or `cover_dimming_class = "bg-white-40"`
+
+## Set a background color behind transparent hero images
+
+If your featured image has transparency, add a Tachyons background color class to `featured_image_class`. This places the color behind the image while keeping the existing fitting and alignment classes.
+
+For the home page hero, set the value in your site configuration:
+
+```toml
+[params]
+featured_image_class = "cover bg-center bg-red"
+```
+
+For a single page or post hero, set the value in that page's front matter:
+
+```toml
+featured_image_class = "cover bg-center bg-yellow"
+```
+
+You can combine this with `cover_dimming_class` to control the overlay opacity. For transparent images, reduce or remove the dimming class if the background color should appear more strongly.
+
+```toml
+cover_dimming_class = "bg-black-20"
+```
+
+This documents the behaviour requested in [gohugo-ananke/ananke#364](https://github.com/gohugo-ananke/ananke/issues/364).

--- a/content/customisation/hero-section.md
+++ b/content/customisation/hero-section.md
@@ -7,6 +7,7 @@ date: 2026-01-16T08:00:00.000+0700
 * [Use the images front matter array](#use-the-images-front-matter-array)
 * [Featured image as Page Resources](#featured-image-as-page-resources)
 * [Other hero settings](#other-hero-settings)
+* [Set a background color behind transparent hero images](#set-a-background-color-behind-transparent-hero-images)
 
 ## Change the hero background
 
@@ -53,3 +54,26 @@ Set it site-wide under `[params]` in your configuration, or per page in front ma
 * Single pages with a featured image: `tc-l pv6 ph3 ph4-ns`
 
 Setting `header_section_class` replaces the default for every header that uses it, so include the alignment and horizontal padding classes you want to keep.
+
+## Set a background color behind transparent hero images
+
+If your featured image has transparency, add a Tachyons background color class to `featured_image_class`. This places the color behind the image while keeping the existing fitting and alignment classes.
+
+For the home page hero, set the value in your site configuration:
+
+```toml
+[params]
+featured_image_class = "cover bg-center bg-red"
+```
+
+For a single page or post hero, set the value in that page's front matter:
+
+```toml
+featured_image_class = "cover bg-center bg-yellow"
+```
+
+You can combine this with `cover_dimming_class` to control the overlay opacity. For transparent images, reduce or remove the dimming class if the background color should appear more strongly.
+
+```toml
+cover_dimming_class = "bg-black-20"
+```


### PR DESCRIPTION
## Summary

- document how to place a Tachyons background colour behind transparent hero images
- show site-wide and page-level `featured_image_class` examples
- mention reducing `cover_dimming_class` when the colour should remain visible

## Context

Refs gohugo-ananke/documentation#15.

The Ananke theme already supports this use case through `featured_image_class`, so this PR clarifies the existing behaviour instead of changing theme templates.

## Verification

- Reviewed the Ananke `page-header.html` and `site-header.html` partials on the `development` branch.
- Confirmed that `featured_image_class` is applied directly to the hero `<header>` element when a featured image exists.
- Confirmed that the documentation repository has no `CONTRIBUTING.md`; used the existing `content/customisation/hero-section.md` page and its current style/structure.
