### PR TITLE
docs: document list page image cards

### DIFF
--- a/content/configuration/general.md
+++ b/content/configuration/general.md
@@ -6,6 +6,7 @@ date: 2026-01-16T08:00:00.000+0700
 * [Activate the contact form](#activate-the-contact-form)
 * [Logo](#logo)
 * [Localize date format](#localize-date-format)
+* [Show or hide dates on pages](#show-or-hide-dates-on-pages)
 * [Show images on list page cards](#show-images-on-list-page-cards)
 
 > [!IMPORTANT]
@@ -41,6 +42,22 @@ date_format = "2. January 2006"
 
 With hugo 0.87.0 and above, you can also use predefined date layouts, like `:date_full`, and it will output localized dates or times. See hugo's documentation of the [`time.Format` function](https://gohugo.io/functions/dateformat/) for more details.
 
+### Show or hide dates on pages
+
+Ananke shows page dates by default where the template includes date output. You can hide dates across pages and summary cards by setting `ananke.pages.show_date` to `false`.
+
+```toml
+[params.ananke.pages]
+show_date = false
+```
+
+You can override this per page with front matter:
+
+```yaml
+ananke:
+  show_date: true
+```
+
 ### Show images on list page cards
 
 By default, list pages render compact summary cards without images. You can opt in to image cards for list pages by enabling the `ananke.pages.show_list_images` parameter.
@@ -50,6 +67,6 @@ By default, list pages render compact summary cards without images. You can opt 
 show_list_images = true
 ```
 
-When enabled, list pages use the same image summary card that is used for recent posts on the home page. Pages without a configured featured image still render without an image.
+When enabled, list pages use the same image summary card that is used for recent posts on the home page. Pages without a configured featured image still render without an image. Date display is controlled separately with `ananke.pages.show_date`.
 
 See [Hero section](/customisation/hero-section/) for information about configuring featured images.

--- a/content/configuration/general.md
+++ b/content/configuration/general.md
@@ -6,6 +6,7 @@ date: 2026-01-16T08:00:00.000+0700
 * [Activate the contact form](#activate-the-contact-form)
 * [Logo](#logo)
 * [Localize date format](#localize-date-format)
+* [Show images on list page cards](#show-images-on-list-page-cards)
 
 > [!IMPORTANT]
 > Please note that Hugo is extensible configurable with more generic or more specific configuration. Please read the documentation about [configuration files](https://gohugo.io/configuration/introduction/#configuration-file) and [configuration directories](https://gohugo.io/configuration/introduction/#configuration-directory) to learn more about this topic. Whenever Ananke's documentation refers to the configuration file it refers to any of these possible locations.
@@ -39,3 +40,16 @@ date_format = "2. January 2006"
 ```
 
 With hugo 0.87.0 and above, you can also use predefined date layouts, like `:date_full`, and it will output localized dates or times. See hugo's documentation of the [`time.Format` function](https://gohugo.io/functions/dateformat/) for more details.
+
+### Show images on list page cards
+
+By default, list pages render compact summary cards without images. You can opt in to image cards for list pages by enabling the `ananke.pages.show_list_images` parameter.
+
+```toml
+[params.ananke.pages]
+show_list_images = true
+```
+
+When enabled, list pages use the same image summary card that is used for recent posts on the home page. Pages without a configured featured image still render without an image.
+
+See [Hero section](/customisation/hero-section/) for information about configuring featured images.


### PR DESCRIPTION
## Summary

* Documents the new `params.ananke.pages.show_list_images` option for list page cards.
* Documents the existing `params.ananke.pages.show_date` date display setting for pages and summary cards.
* Adds a short explanation that pages without featured images still render without an image.
* Links users to the existing hero section documentation for featured image setup.

Related to gohugo-ananke/ananke#217.

Theme PR: gohugo-ananke/ananke#971

## Verification

* Reviewed the existing documentation structure and extended `content/configuration/general.md` instead of creating a new page.
* Compared this branch against `development`; only `content/configuration/general.md` changed.