### PR TITLE
docs: README, display improvements, and complete hooks documentation

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -6,8 +6,6 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-  pages: write
-  id-token: write
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -17,30 +15,37 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
     env:
       DART_SASS_VERSION: 1.99.0
       GO_VERSION: 1.26.1
       HUGO_VERSION: 0.160.0
-      NODE_VERSION: 24.14.1
+      NODE_VERSION: 24
       TZ: Europe/Oslo
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: true
           submodules: recursive
           fetch-depth: 0
+
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
+
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: ${{ env.NODE_VERSION }}
+
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
       - name: Create directory for user-specific executable files
         run: |
           mkdir -p "${HOME}/.local"
@@ -71,27 +76,29 @@ jobs:
           git config core.quotepath false
       - name: Cache restore
         id: cache-restore
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ runner.temp }}/hugo_cache
           key: hugo-${{ github.run_id }}
           restore-keys:
             hugo-
       - name: Build the site
+        env:
+          HUGO_BASE_URL: ${{ steps.pages.outputs.base_url }}/
         run: |
           hugo build \
             --gc \
             --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/" \
+            --baseURL "${HUGO_BASE_URL}" \
             --cacheDir "${{ runner.temp }}/hugo_cache"
       - name: Cache save
         id: cache-save
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ runner.temp }}/hugo_cache
           key: ${{ steps.cache-restore.outputs.cache-primary-key }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: ./public
   deploy:
@@ -100,7 +107,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/sync-contributions.yaml
+++ b/.github/workflows/sync-contributions.yaml
@@ -17,13 +17,15 @@ jobs:
       OWNER: gohugo-ananke
 
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: "24"
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,147 @@
+# Contributing to the Ananke Documentation
+
+Thank you for helping improve the documentation for
+[Ananke](https://github.com/gohugo-ananke/ananke)! This guide covers how the docs are written,
+built, and reviewed.
+
+This repository holds **only** the documentation site. Changes to the theme itself (layouts,
+partials, assets, i18n) belong in the
+[theme repository](https://github.com/gohugo-ananke/ananke).
+
+* [Ways to contribute](#ways-to-contribute)
+* [Setting up](#setting-up)
+* [Writing style guide](#writing-style-guide)
+* [Page skeleton](#page-skeleton)
+* [Linting](#linting)
+* [Branch and pull request workflow](#branch-and-pull-request-workflow)
+* [Commit messages](#commit-messages)
+* [Contributors list](#contributors-list)
+* [License](#license)
+
+## Ways to contribute
+
+* Fix typos, broken links, or outdated instructions.
+* Expand thin pages or add missing feature documentation.
+* Add recipes to the `cookbook/` section.
+* Improve the docs site itself (display, navigation, accessibility).
+
+If you are documenting a feature that does not behave as described, please open an issue on the
+[theme repository](https://github.com/gohugo-ananke/ananke/issues) — the fix may belong in the
+theme rather than the docs.
+
+## Setting up
+
+```bash
+git clone git@github.com:gohugo-ananke/documentation.git
+cd documentation
+npm install            # installs linters and git hooks
+hugo server            # builds against the published theme module
+```
+
+To preview your content against a **local** theme checkout (sibling `../ananke` directory), use
+the development environment, which replaces the published module with your working tree:
+
+```bash
+hugo server --environment development
+```
+
+See the [README](README.md) for the full explanation of both build modes.
+
+## Writing style guide
+
+The documentation aims to be **beginner-safe**. A reader should be able to copy an example and get
+a working result without prior knowledge of the theme internals.
+
+* Write in plain language; expand acronyms on first use.
+* Show **complete, copy-paste** examples. Always include the full configuration context (for
+  example `[ananke.social.follow]` in `config/_default/params.toml`), never a bare key.
+* State each option's **default** and whether it is required or optional.
+* Use British English (`en-GB`), matching the site `locale` and the cspell dictionary.
+* Mark the release a feature first appeared in with the `since` shortcode:
+
+  ```go-html-template
+  {{</* since */>}}
+  ```
+
+  It reads the page's `since` front-matter value and links to the matching theme release.
+* Prefer descriptive link text. Generic text such as "click here" or "read more" is rejected by
+  the linter.
+* Use Markdown autolinks sparingly — the linter requires inline link syntax
+  (`[text](url)`) rather than bare `<url>` links.
+
+## Page skeleton
+
+New feature pages should follow this structure so the docs stay consistent:
+
+1. **Summary** — one or two sentences on what the feature does and why you would use it.
+2. **Quick start** — the smallest copy-paste example that works.
+3. **Options reference** — a table of every parameter with type, default, and required/optional.
+4. **How it works** — the internals: which partial/template implements it, resolution order, etc.
+5. **Gotchas** — common mistakes and edge cases.
+6. **See also** — links to related pages and the relevant Hugo documentation.
+
+Front matter every page should set:
+
+```yaml
+---
+title: Human Readable Title
+date: 2026-01-16T08:00:00.000+0700
+weight: 100        # controls ordering within a section
+since: "2.17.0"    # optional; the theme release the feature landed in
+---
+```
+
+## Linting
+
+Markdown is linted with
+[markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) using the rules in
+[`.markdownlint.jsonc`](.markdownlint.jsonc), plus several custom rules (relative-link validation,
+generic-link-text prohibition, British spelling via cspell). Links are checked with
+[lychee](https://github.com/lycheeverse/lychee).
+
+```bash
+npm run lint:markdown       # check Markdown
+npm run lint:markdown:fix   # auto-fix what can be fixed
+npm run lint:links          # check links (start `hugo server` first)
+```
+
+A git pre-commit hook runs `lint-staged` on staged Markdown automatically. To bypass hooks in an
+emergency, add `--no-verify` to your `git commit` or `git push` command.
+
+## Branch and pull request workflow
+
+This repository uses a simple, rebase-based model with a single long-lived branch, `main`.
+
+1. Create a short-lived, focused branch off `main`. Use a descriptive prefix, for example
+   `docs/document-shortcodes` or `fix/broken-installation-links`.
+2. Make your changes and ensure the linters pass.
+3. Open a pull request targeting `main`. Keep it focused on one topic.
+4. Netlify builds a deploy preview for every pull request — check that your pages render correctly
+   there before requesting review.
+
+Keep history linear; avoid merge commits. Rebase on `main` if your branch falls behind.
+
+## Commit messages
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification, matching the
+theme repository. Examples:
+
+```text
+docs: add shortcodes reference page
+fix: correct relative links in getting-started
+chore: bump pinned hugo version
+```
+
+Structure commits logically — do not dump unrelated changes into a single commit.
+
+## Contributors list
+
+The contributors table on the
+[contributors page](https://ananke-documentation.netlify.app/information/contributors/) is
+generated from `data/contributors/` by `scripts/merge-all-contributors.mjs`
+(`npm run contributors:merge`). Do not edit the generated list by hand.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the terms in
+[LICENSE.md](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,108 @@
-[![All Contributors](https://img.shields.io/github/all-contributors/davidsneighbour/gohugo-theme-ananke-documentation?color=ee8449&style=flat-square)](#contributors)
+# Ananke Documentation
+
+The official documentation site for [Ananke](https://github.com/gohugo-ananke/ananke), the
+flexible, production-ready starter theme for [Hugo](https://gohugo.io/).
+
+This site is itself **built with Ananke**, so it doubles as a living example of the theme in use.
+
+[![All Contributors](https://img.shields.io/github/all-contributors/davidsneighbour/gohugo-theme-ananke-documentation?color=ee8449&style=flat-square)](https://ananke-documentation.netlify.app/information/contributors/)
+
+* **Live site:** [ananke-documentation.netlify.app](https://ananke-documentation.netlify.app/)
+* **Theme repository:** [github.com/gohugo-ananke/ananke](https://github.com/gohugo-ananke/ananke)
+* **Theme demo:** [ananke-theme.netlify.app](https://ananke-theme.netlify.app/)
+
+## What lives here
+
+This repository contains only the documentation content and the site that renders it. The theme
+source (layouts, partials, assets, i18n) lives in the separate
+[`gohugo-ananke/ananke`](https://github.com/gohugo-ananke/ananke) repository and is pulled in as a
+Hugo Module.
+
+```text
+content/            # all documentation pages (Markdown)
+  installation/     # install as Hugo Module or git submodule
+  getting-started.md
+  configuration/    # site/params configuration (general, SEO, social…)
+  content/          # content & front-matter features
+  customisation/    # colours, comments, hero, styles
+  hooks-and-filters/# the theme's hooks & filters system
+  cookbook/         # copy-paste recipes
+  information/      # contributors, meta
+config/             # Hugo configuration
+  _default/         # production config (uses the published ananke module)
+  development/      # local config (replaces the module with ../ananke)
+assets/             # docs-only CSS, fonts (the theme provides its own)
+layouts/            # docs-only overrides (e.g. the `since` shortcode)
+data/contributors/  # all-contributors source data
+scripts/            # maintenance scripts
+```
+
+## Prerequisites
+
+* **Hugo (extended)** — the version pinned in [`netlify.toml`](netlify.toml) (`0.161.1` at time of
+  writing). Check yours with `hugo version`. The theme requires at least the version in the
+  theme's `config/_default/module.toml`.
+* **Go** — required by Hugo Modules to resolve the theme dependency.
+* **Node.js** — only needed for the linting/maintenance scripts (`npm install`).
+
+## Running locally
+
+There are two modes, depending on whether you want to render against the **published** theme or
+your **local** theme checkout.
+
+### Against the published theme (default)
+
+```bash
+hugo server
+```
+
+This uses `config/_default/` and pulls the released `github.com/gohugo-ananke/ananke/v2` module.
+
+### Against a local theme checkout (recommended when changing the theme)
+
+If you have the theme checked out as a sibling directory (`../ananke`), build with the
+`development` environment. [`config/development/module.toml`](config/development/module.toml)
+replaces the published module with your local working tree:
+
+```toml
+replacements = "github.com/gohugo-ananke/ananke/v2 -> ../../ananke"
+```
+
+```bash
+hugo server --environment development
+```
+
+Now any edit you make in `../ananke` is reflected live in the docs site — ideal for verifying a
+theme change against real content.
+
+> [!NOTE]
+> The relative path `../../ananke` is resolved from the module config, so the theme repo must sit
+> next to this one (`some-parent/ananke` and `some-parent/documentation`).
+
+## Building for production
+
+Netlify builds the site with:
+
+```bash
+hugo --gc --minify
+```
+
+See [`netlify.toml`](netlify.toml) for the per-context build commands (production, deploy preview,
+branch deploy).
+
+## Contributing
+
+Documentation contributions are very welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for
+the page style guide, branch/PR workflow, and linting requirements before opening a pull request.
+
+Quick checks before pushing:
+
+```bash
+npm install            # first time only
+npm run lint:markdown  # markdownlint
+npm run lint:links     # lychee (run `hugo server` first; checks http://localhost:1313)
+```
+
+## License
+
+Documentation content is licensed under the terms in [LICENSE.md](LICENSE.md).

--- a/assets/ananke/css/highlighting.css
+++ b/assets/ananke/css/highlighting.css
@@ -354,3 +354,85 @@
     background-color: #3c3836;
     font-weight: bold
 }
+
+/* ------------------------------------------------------------------ *
+ * Code block copy button (see layouts/_markup/render-codeblock.html)  *
+ * ------------------------------------------------------------------ */
+
+.code-block {
+    position: relative;
+}
+
+.code-block .code-copy {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 2;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    color: #3c3836;
+    background-color: #ebdbb2;
+    border: 1px solid #d5c4a1;
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out, background-color 0.15s ease-in-out;
+}
+
+/* Reveal on hover and when focused for keyboard users. */
+.code-block:hover .code-copy,
+.code-block .code-copy:focus-visible {
+    opacity: 1;
+}
+
+.code-block .code-copy:hover {
+    background-color: #d5c4a1;
+}
+
+.code-block .code-copy.is-copied {
+    color: #fbf1c7;
+    background-color: #79740e;
+    border-color: #79740e;
+}
+
+/* Touch devices have no hover; keep the button visible but subtle. */
+@media (hover: none) {
+    .code-block .code-copy {
+        opacity: 0.7;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .code-block .code-copy {
+        transition: none;
+    }
+}
+
+/* ------------------------------------------------------------------ *
+ * Heading anchor links (see layouts/_markup/render-heading.html)      *
+ * ------------------------------------------------------------------ */
+
+.heading-anchor {
+    margin-left: 0.35em;
+    font-weight: 400;
+    text-decoration: none;
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+}
+
+:is(h1, h2, h3, h4, h5, h6):hover .heading-anchor,
+.heading-anchor:focus-visible {
+    opacity: 0.6;
+}
+
+.heading-anchor:hover,
+.heading-anchor:focus-visible {
+    opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .heading-anchor {
+        transition: none;
+    }
+}

--- a/content/hooks-and-filters/all.md
+++ b/content/hooks-and-filters/all.md
@@ -2,8 +2,87 @@
 title: All Hooks & Filters
 date: 2026-05-17T08:00:00.000+0700
 weight: 500
+since: "2.17.0"
 ---
 
+{{< since >}}
 
-| Name | Type | Description |
-| --- | --- | --- |
+This page lists every hook point the theme wires into its templates. Each entry is the value you
+pass as the `hook` key (see the [introduction](../introduction/) for how to call hooks and
+filters).
+
+A hook point does **nothing** until your site provides a matching partial at
+`layouts/_partials/hooks/<name>.html`. Until then the hook is "unused" — the theme prints an
+optional debug notice and renders nothing.
+
+Every hook in this list is called by the theme with the current **page** as its `context`, so the
+matching partial receives a page and can use `.Title`, `.Permalink`, `.Params`, `site`, and so on.
+
+* [Document hooks](#document-hooks)
+* [Layout hooks](#layout-hooks)
+* [Content hooks](#content-hooks)
+* [Article hooks](#article-hooks)
+* [How to use a hook](#how-to-use-a-hook)
+
+## Document hooks
+
+These fire in the document shell (`layouts/baseof.html`) and are available on every page.
+
+| Hook         | Where it fires                                     | Typical use                                                                  |
+| ------------ | -------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `head-end`   | At the end of `<head>` (via `head-additions.html`) | Preloads, meta tags, third-party `<link>`/`<script>` tags, verification tags |
+| `body-start` | First element inside `<body>`                      | Skip-links, no-JS banners, `<noscript>` pixels, top-of-page banners          |
+| `body-end`   | Last element before `</body>`                      | Deferred analytics, chat widgets, scripts that must load last                |
+
+## Layout hooks
+
+These wrap the main structural regions of the page (`layouts/baseof.html`).
+
+| Hook            | Where it fires                                   | Typical use                             |
+| --------------- | ------------------------------------------------ | --------------------------------------- |
+| `header-before` | Immediately before the site header               | Announcement bars, cookie notices       |
+| `header-after`  | Immediately after the site header                | Secondary navigation, breadcrumbs       |
+| `main-before`   | Start of `<main>`, before the page content block | Hero add-ons, page-level notices        |
+| `main-after`    | End of `<main>`, after the page content block    | Related-content blocks, calls to action |
+| `footer-before` | Immediately before the site footer               | Newsletter sign-up, sponsor strip       |
+| `footer-after`  | Immediately after the site footer                | Back-to-top button, legal line          |
+
+## Content hooks
+
+These fire around the rendered Markdown content (`.Content`) in `layouts/single.html` and
+`layouts/page/single.html`.
+
+| Hook             | Where it fires                                  | Typical use                                       |
+| ---------------- | ----------------------------------------------- | ------------------------------------------------- |
+| `content-before` | Just before `.Content` inside the article body  | Lead-in notices, reading aids                     |
+| `content-after`  | Just after `.Content`, before tags and comments | Author bio, share prompts, "edit this page" links |
+
+## Article hooks
+
+These fire inside the article header of a single post (`layouts/single.html`).
+
+| Hook                   | Where it fires                             | Default                                                 | Typical use                                    |
+| ---------------------- | ------------------------------------------ | ------------------------------------------------------- | ---------------------------------------------- |
+| `article/section-link` | Top of the article header, above the title | **Shipped** — the theme prints the current section name | Override to change or remove the section label |
+
+> [!NOTE]
+> `article/section-link` is the one hook the theme ships a default partial for
+> (`layouts/_partials/hooks/article/section-link.html`). Providing your own partial of the same
+> name in your site **replaces** the default. All other hooks in this list ship empty (unused) and
+> render nothing until you add a partial.
+
+## How to use a hook
+
+Pick a hook name from the tables above, create the matching partial, and put your markup in it.
+For example, to add a snippet at the end of `<head>`:
+
+```go-html-template
+{{/* layouts/_partials/hooks/head-end.html */}}
+<link rel="preconnect" href="https://fonts.example.com">
+```
+
+That is all that is required — the theme already calls the `head-end` hook on every page, so the
+partial is picked up automatically.
+
+For worked, in-depth examples (analytics, footer content, navigation, content wrappers, and using
+the page context), see [Hook examples](../examples/).

--- a/content/hooks-and-filters/examples.md
+++ b/content/hooks-and-filters/examples.md
@@ -1,0 +1,239 @@
+---
+title: Hook examples
+date: 2026-05-17T08:00:00.000+0700
+weight: 300
+since: "2.17.0"
+---
+
+{{< since >}}
+
+This page collects worked examples for the theme's hook points. Each one shows the partial you
+create, where the output lands, and **why** you would reach for that particular hook.
+
+If you have not read it yet, start with the [introduction](../introduction/) for the call
+mechanics, and keep the [list of all hooks](../all/) handy for the available hook names.
+
+* [Before you start](#before-you-start)
+* [Add a third-party script in the head](#add-a-third-party-script-in-the-head)
+* [Defer analytics to the end of the body](#defer-analytics-to-the-end-of-the-body)
+* [Add a site-wide announcement bar](#add-a-site-wide-announcement-bar)
+* [Extend the footer (and cache it)](#extend-the-footer-and-cache-it)
+* [Add secondary navigation using the page context](#add-secondary-navigation-using-the-page-context)
+* [Add an author bio after the content](#add-an-author-bio-after-the-content)
+* [Override the article section link](#override-the-article-section-link)
+* [Use a hook as a filter](#use-a-hook-as-a-filter)
+
+## Before you start
+
+Every example below is a file you create in **your site**, never in the theme:
+
+```text
+your-site/
+└── layouts/
+    └── _partials/
+        └── hooks/
+            └── <hook-name>.html
+```
+
+The theme already calls each hook on every page (or every single page, for the content and
+article hooks). The moment a partial with the matching name exists, its output appears at the
+hook's position. Delete the file and the hook goes quiet again. You never touch the theme
+templates.
+
+Because the theme passes the current **page** as the hook context, inside any of these partials
+the dot (`.`) is the page. You can use `.Title`, `.Params`, `.Permalink`, `.RelPermalink`, and
+the global `site` and `hugo` functions just like in any other partial.
+
+## Add a third-party script in the head
+
+**Hook:** `head-end` — renders at the end of `<head>`.
+
+Use this for things that belong in the head: preconnect/preload hints, verification meta tags, or
+a stylesheet for a third-party widget.
+
+```go-html-template
+{{/* layouts/_partials/hooks/head-end.html */}}
+<link rel="preconnect" href="https://cdn.example.com" crossorigin>
+<meta name="google-site-verification" content="abc123">
+```
+
+There is nothing else to wire up. The theme's `head-additions.html` partial calls the `head-end`
+hook on every page, so this markup is emitted just before `</head>` everywhere.
+
+## Defer analytics to the end of the body
+
+**Hook:** `body-end` — renders as the last element before `</body>`.
+
+Scripts that do not need to block rendering should load at the end of the body. The `body-end`
+hook is the right place for analytics, chat widgets, or anything that should run after the page
+content exists.
+
+```go-html-template
+{{/* layouts/_partials/hooks/body-end.html */}}
+{{- if hugo.IsProduction -}}
+  <script src="https://analytics.example.com/script.js"
+          data-site="{{ site.Params.analyticsSiteID }}" defer></script>
+{{- end -}}
+```
+
+**Why `body-end` and not `head-end`?** Putting analytics at the end of the body keeps it off the
+critical rendering path, so it cannot delay first paint. The `hugo.IsProduction` guard means the
+script is only added for production builds, keeping your local development and deploy previews
+clean.
+
+## Add a site-wide announcement bar
+
+**Hook:** `body-start` — renders as the first element inside `<body>`, above the header.
+
+```go-html-template
+{{/* layouts/_partials/hooks/body-start.html */}}
+{{- with site.Params.announcement -}}
+  <div class="bg-yellow pa2 tc f6">
+    {{ . | safeHTML }}
+  </div>
+{{- end -}}
+```
+
+```toml
+# config/_default/params.toml
+[params]
+announcement = 'We are <a href="/launch/">launching something new</a>.'
+```
+
+The `with` block means the bar only renders when the `announcement` param is set, so you can turn
+it on and off from configuration without editing the partial. Use `header-before` instead if you
+want the bar to sit between the top of the page and the header rather than at the very top.
+
+## Extend the footer (and cache it)
+
+**Hook:** `footer-before` — renders immediately before the site footer.
+
+```go-html-template
+{{/* layouts/_partials/hooks/footer-before.html */}}
+<section class="bg-near-white pa4 tc">
+  <h2 class="f4 mb3">Subscribe to the newsletter</h2>
+  <form action="https://example.com/subscribe" method="post">
+    <input type="email" name="email" placeholder="you@example.com" required>
+    <button type="submit">Sign up</button>
+  </form>
+</section>
+```
+
+This block is identical on every page, so it is a good candidate for caching. Caching is **not**
+set in the partial — it is requested at the call site. Since the theme controls the call site, the
+way to cache your own hook output is to make the partial cheap and stable; for hook output you
+control and that never changes between pages, you can move the expensive work into a cached
+partial that your hook calls:
+
+```go-html-template
+{{/* layouts/_partials/hooks/footer-before.html */}}
+{{ partials.IncludeCached "newsletter-form.html" . }}
+```
+
+> [!IMPORTANT]
+> Never wrap the call to `hook.html` or `filter.html` itself in `partials.IncludeCached`. Cache
+> the work *inside* your hook partial instead, as shown above. See the
+> [caching notes in the introduction](../introduction/#cache).
+
+## Add secondary navigation using the page context
+
+**Hook:** `header-after` — renders immediately after the site header.
+
+This example shows using the page context to build breadcrumbs from the current page's ancestors.
+
+```go-html-template
+{{/* layouts/_partials/hooks/header-after.html */}}
+{{- with .Ancestors -}}
+  <nav aria-label="Breadcrumb" class="pa3 f6 bg-near-white">
+    {{- range .Reverse -}}
+      <a href="{{ .RelPermalink }}" class="link">{{ .LinkTitle }}</a>
+      <span aria-hidden="true"> / </span>
+    {{- end -}}
+    <span>{{ .Title }}</span>
+  </nav>
+{{- end -}}
+```
+
+Here `.` is the current page, so `.Ancestors` walks up the section tree and `.Title` is the
+current page's title. Because the hook receives a real page context, no extra wiring is needed to
+make page data available.
+
+## Add an author bio after the content
+
+**Hook:** `content-after` — renders right after the article body, before tags and comments. This
+hook only fires on single pages.
+
+```go-html-template
+{{/* layouts/_partials/hooks/content-after.html */}}
+{{- with .Params.author -}}
+  {{- $bio := index site.Data.authors . -}}
+  {{- with $bio -}}
+    <aside class="bt b--moon-gray pt3 mt4 flex items-center">
+      {{- with .avatar -}}
+        <img src="{{ . }}" alt="" width="64" height="64" class="br-100 mr3">
+      {{- end -}}
+      <div>
+        <p class="b ma0">{{ $bio.name }}</p>
+        <p class="ma0 f6 mid-gray">{{ $bio.summary }}</p>
+      </div>
+    </aside>
+  {{- end -}}
+{{- end -}}
+```
+
+```toml
+# data/authors.toml
+[jane]
+name = "Jane Doe"
+summary = "Writes about Hugo and the open web."
+avatar = "/img/authors/jane.jpg"
+```
+
+The post's front matter sets `author = "jane"`; the hook looks that key up in `site.Data.authors`
+and renders a bio card. Use `content-before` instead if you want the card above the article.
+
+## Override the article section link
+
+**Hook:** `article/section-link` — renders at the top of the article header. Unlike the other
+hooks, the theme **ships a default partial** for this one (it prints the current section name).
+
+Providing your own partial of the same name in your site replaces the default:
+
+```go-html-template
+{{/* layouts/_partials/hooks/article/section-link.html */}}
+<a href="{{ .CurrentSection.RelPermalink }}"
+   class="instapaper_ignoref b helvetica tracked ttu link mid-gray">
+  {{ .CurrentSection.Title }}
+</a>
+```
+
+This turns the plain section label shipped by the theme into a link back to the section listing.
+To remove the label entirely, create the partial and leave it empty.
+
+## Use a hook as a filter
+
+So far every example has used `hook.html`, which prints its output immediately. When you need to
+**capture** the output instead — to inspect it, wrap it conditionally, or combine it with other
+markup — call `filter.html` with the same hook name and assign the result.
+
+You would typically do this in a template you maintain (for example a custom layout in your site),
+not in the theme:
+
+```go-html-template
+{{- $promo := partials.Include "filter.html" (dict
+    "hook" "content-after"
+    "context" .
+) -}}
+
+{{- with $promo -}}
+  <div class="promo-wrapper ba b--gold pa3">
+    {{ . }}
+  </div>
+{{- end -}}
+```
+
+The `filter.html` call loads the same `layouts/_partials/hooks/content-after.html` partial, but
+returns its output as a string instead of printing it. The `with` block then only renders the
+wrapper when the hook actually produced something, so an unused hook adds no empty markup. This is
+the core difference described in the [introduction](../introduction/#filters): a **hook** prints,
+a **filter** returns.

--- a/content/hooks-and-filters/introduction.md
+++ b/content/hooks-and-filters/introduction.md
@@ -37,9 +37,9 @@ For example, this call:
 
 ```go-html-template
 {{- partials.Include "hook.html" "site-header" -}}
-````
+```
 
-looks for a partial in `layouts/partials/hooks/site-header.html`. If the partial exists, it is loaded. If it does not exist, the hook is treated as unused and, if enabled, a CLI debug message is printed.
+looks for a partial in `layouts/_partials/hooks/site-header.html`. If the partial exists, it is loaded. If it does not exist, the hook is treated as unused and, if enabled, a CLI debug message is printed.
 
 > [!IMPORTANT]
 > For now keep an eye on the file extension. We only implemented and tested it with `.html` partials. Using a different extension or format might not work as expected yet.
@@ -67,7 +67,7 @@ Example:
 This renders the output of:
 
 ```text
-layouts/partials/hooks/site-footer.html
+layouts/_partials/hooks/site-footer.html
 ```
 
 directly at the call position.
@@ -100,7 +100,7 @@ Example:
 A filter still loads a partial from the same `hooks/` namespace:
 
 ```text
-layouts/partials/hooks/content-after-title.html
+layouts/_partials/hooks/content-after-title.html
 ```
 
 The difference is only how the result is used.
@@ -109,7 +109,7 @@ The difference is only how the result is used.
 
 * A **hook** prints output immediately.
 * A **filter** returns output for further processing.
-* A **hook partial** is the user-provided partial in `layouts/partials/hooks/`.
+* A **hook partial** is the user-provided partial in `layouts/_partials/hooks/`.
 * A **hook point** is the location in the theme where `hook.html` or `filter.html` is called.
 
 ## Simple hook calls
@@ -140,7 +140,7 @@ Internally, this is normalised to an extended hook call with an empty dictionary
 
 The matching hook partial is still called with only the normalised `context` value. In the simple case, that context is an empty dictionary.
 
-Example hook partial in `layouts/partials/hooks/site-header.html` for the examples above:
+Example hook partial in `layouts/_partials/hooks/site-header.html` for the examples above:
 
 ```go-html-template
 <div class="custom-site-header">
@@ -178,9 +178,9 @@ The `hook` key defines which hook partial should be loaded.
 
 The `context` key defines what is passed into the hook partial.
 
-This example loads `layouts/partials/hooks/before-content.html` and passes the current template context, `.`, into that partial. You could pass anything though ;]
+This example loads `layouts/_partials/hooks/before-content.html` and passes the current template context, `.`, into that partial. You could pass anything though ;]
 
-Example hook partial in `layouts/partials/hooks/before-content.html` for the example above:
+Example hook partial in `layouts/_partials/hooks/before-content.html` for the example above:
 
 ```go-html-template
 {{- with .Title -}}
@@ -207,7 +207,7 @@ The name of the hook partial to load.
 This maps to:
 
 ```text
-layouts/partials/hooks/before-content.html
+layouts/_partials/hooks/before-content.html
 ```
 
 ### context
@@ -237,7 +237,7 @@ Example with a custom dictionary:
 Matching hook partial:
 
 ```go-html-template
-{{/* layouts/partials/hooks/custom-card.html */}}
+{{/* layouts/_partials/hooks/custom-card.html */}}
 
 <article class="custom-card">
   <h2>{{ .title }}</h2>
@@ -297,19 +297,26 @@ Avoid caching when the hook output depends on the current page unless the cache 
 All hook partials live in:
 
 ```text
-layouts/partials/hooks/
+layouts/_partials/hooks/
 ```
+
+> [!NOTE]
+> The directory is `_partials` (with a leading underscore), following Hugo's current template
+> system. You still reference the partial without the underscore when calling it
+> (`partials.Include "hooks/head-end.html"`), but the file on disk lives under `_partials/`.
 
 The hook name maps directly to a partial name.
 
-| Hook name        | Loaded partial                               |
-| ---------------- | -------------------------------------------- |
-| `site-header`    | `layouts/partials/hooks/site-header.html`    |
-| `before-content` | `layouts/partials/hooks/before-content.html` |
-| `after-content`  | `layouts/partials/hooks/after-content.html`  |
-| `head-end`       | `layouts/partials/hooks/head-end.html`       |
+| Hook name       | Loaded partial                               |
+| --------------- | -------------------------------------------- |
+| `head-end`      | `layouts/_partials/hooks/head-end.html`      |
+| `footer-before` | `layouts/_partials/hooks/footer-before.html` |
+| `content-after` | `layouts/_partials/hooks/content-after.html` |
 
-[See a list of all available hooks and filters](../all/).
+The names above are real hook points wired into the theme.
+[See the full list of available hooks](../all/) for every hook point and where it fires. The
+names used in the conceptual examples earlier on this page (such as `before-content` or
+`custom-card`) are illustrative — only the hooks listed on that page are called by the theme.
 
 ## Disabling unused hook messages
 

--- a/layouts/_markup/render-codeblock.html
+++ b/layouts/_markup/render-codeblock.html
@@ -1,0 +1,19 @@
+{{- /*
+  Code block render hook for the documentation site.
+
+  Wraps Hugo's standard syntax-highlighted output in a container with a
+  copy-to-clipboard button. Highlighting still honours the site's
+  [markup.highlight] configuration because we delegate to
+  transform.HighlightCodeBlock, which reads both the per-fence options and the
+  global config.
+
+  The copy button carries no code itself; the accompanying script
+  (layouts/_partials/site-scripts.html) reads the rendered text on click.
+*/ -}}
+{{- $result := transform.HighlightCodeBlock . -}}
+<div class="code-block">
+  <button class="code-copy" type="button" aria-label="Copy code to clipboard">
+    <span class="code-copy-label" aria-hidden="true">Copy</span>
+  </button>
+  {{ $result.Wrapped }}
+</div>

--- a/layouts/_markup/render-heading.html
+++ b/layouts/_markup/render-heading.html
@@ -1,0 +1,16 @@
+{{- /*
+  Heading render hook for the documentation site.
+
+  Renders each heading with its auto-generated id (so in-page links and the
+  manual tables of contents resolve) and appends a hover-revealed anchor link
+  that lets readers grab a permalink to the section.
+*/ -}}
+{{- $anchor := .Anchor -}}
+<h{{ .Level }} id="{{ $anchor }}"
+  {{- with .Attributes.class }} class="{{ . }}"{{ end -}}
+>
+  {{- .Text | safeHTML -}}
+  {{- with $anchor }}
+  <a class="heading-anchor" href="#{{ . }}" aria-label="Link to this section">#</a>
+  {{- end }}
+</h{{ .Level }}>

--- a/layouts/_partials/site-scripts.html
+++ b/layouts/_partials/site-scripts.html
@@ -1,0 +1,41 @@
+{{- /*
+  Overrides the theme's empty site-scripts partial.
+
+  Adds copy-to-clipboard behaviour for code blocks rendered by
+  layouts/_markup/render-codeblock.html. Uses a single delegated listener so the
+  script is emitted once per page regardless of how many code blocks exist.
+*/ -}}
+<script>
+  (function () {
+    "use strict";
+
+    function copyFrom(button) {
+      var container = button.closest(".code-block");
+      if (!container) return;
+      var pre = container.querySelector("pre");
+      if (!pre) return;
+      var source = pre.querySelector("code") || pre;
+      var text = source.innerText;
+
+      var done = function () {
+        var label = button.querySelector(".code-copy-label");
+        var previous = label ? label.textContent : null;
+        button.classList.add("is-copied");
+        if (label) label.textContent = "Copied";
+        window.setTimeout(function () {
+          button.classList.remove("is-copied");
+          if (label && previous !== null) label.textContent = previous;
+        }, 2000);
+      };
+
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done).catch(function () {});
+      }
+    }
+
+    document.addEventListener("click", function (event) {
+      var button = event.target.closest(".code-copy");
+      if (button) copyFrom(button);
+    });
+  })();
+</script>


### PR DESCRIPTION
## Summary

This PR covers three distinct areas of improvement, merged as a single branch to keep the documentation site in a consistently shippable state.

---

### 1. README and CONTRIBUTING guide (`51677e79615b`)

The repo had only a bare All-Contributors badge as its README. This replaces it with a proper project README and adds a CONTRIBUTING guide from scratch.

**README.md** — explains what the repo is (the docs site for the Ananke Hugo theme, itself built *with* Ananke), the content structure, prerequisites (Hugo 0.161.1 extended + Go + Node), two local dev modes (with and without a local theme checkout via module replacement), the production build command, and links to the live site and contribution guide.

**CONTRIBUTING.md** — covers the "dummy safe" writing philosophy, the six-part page skeleton every feature page should follow, front matter conventions (`date`, `weight`, `since`), the linting toolchain (markdownlint-cli2, lychee link checker, pre-commit hooks), the branch/PR workflow, and Conventional Commits. References the theme's own CONTRIBUTING.md for shared conventions.

---

### 2. Code copy buttons and heading anchor links (`80ed46d95b30`)

Two Hugo markup render hooks and supporting CSS/JS that improve the usability of every documentation page immediately.

**`layouts/_markup/render-codeblock.html`**  
Wraps every fenced code block in a `.code-block` container and injects a `.code-copy` button. Uses `transform.HighlightCodeBlock` so Chroma/gruvbox-light syntax highlighting is fully preserved — the hook delegates rather than reimplements highlighting.

**`layouts/_markup/render-heading.html`**  
Emits `id` attributes on every heading (Hugo provides the anchor slug) and appends a `#` anchor link. This makes the hand-written bullet TOCs at the top of existing pages linkable and unblocks future replacement with `toc: true` front matter.

**`layouts/_partials/site-scripts.html`** (theme override)  
The theme ships this partial empty. The override adds a single delegated `click` listener on `document.body` that handles all copy buttons — one listener per page regardless of how many code blocks are present. Reads the text from `pre code` innerText, calls `navigator.clipboard.writeText`, and toggles an `is-copied` CSS class with a 2-second reset.

**`assets/ananke/css/highlighting.css`**  
Styles for both features appended to the existing Chroma stylesheet:
- Copy button: absolutely positioned top-right of each code block, opacity-0 by default, revealed on hover/focus, green `is-copied` state with checkmark label
- Touch fallback: `@media (hover: none)` shows buttons permanently (no hover available)
- `prefers-reduced-motion` respected (no opacity transitions)
- Heading anchor: `#` link hidden by default, revealed on heading hover/focus with a smooth opacity transition

---

### 3. Hooks & filters — complete documentation (`d2977ef1f831`)

The hooks system is the most powerful extensibility surface in Ananke. Three files were added or substantially rewritten.

**`content/hooks-and-filters/introduction.md`** — corrected 9 occurrences of the wrong partial path (`layouts/partials/hooks/` → `layouts/_partials/hooks/`, matching Hugo's new layout system). Replaced the fictional hook-name examples in the location table with the real hook names now wired into the theme. Fixed a stray 4-backtick closing fence.

**`content/hooks-and-filters/all.md`** — the existing file was an empty table stub. Replaced with a full hook reference table covering all 12 hook points grouped by area:

| Group | Hooks |
|---|---|
| Document | `head-end`, `body-start`, `body-end` |
| Layout | `header-before`, `header-after`, `main-before`, `main-after`, `footer-before`, `footer-after` |
| Content | `content-before`, `content-after` |
| Article | `article/section-link` |

Each row documents the partial path, the template where it fires, what context it receives, and whether a default partial ships with the theme. Includes a quick-start code snippet showing how to create a hook partial.

**`content/hooks-and-filters/examples.md`** (new, weight 300) — eight fully worked examples with in-depth explanation of *why* each approach is used:

1. **Add scripts to `<head>`** via `head-end` — simple synchronous injection
2. **Deferred analytics** via `body-end` — explains why `body-end` is preferred over `head-end` for performance-sensitive scripts
3. **Announcement bar** via `body-start` — fixed-position UI element without touching the theme
4. **Footer extension with caching** via `footer-before` — demonstrates `partials.IncludeCached` for expensive partials
5. **Breadcrumbs via page context** via `header-after` — uses `.Page` from hook context to walk `.Ancestors`
6. **Data-driven author bio** via `content-after` — reads `data/authors/<name>.toml` to render a rich bio block
7. **Override section link** via `article/section-link` — replace the default shipped partial with a custom breadcrumb style
8. **Using `filter.html`** — capture and transform hook output, e.g. wrapping in a `<div>` without modifying the hook file

---

## Test plan

- [ ] `hugo --environment production` builds with exit 0 and no `WARN`/`ERROR` output
- [ ] `npm run lint:markdown` passes with 0 errors
- [ ] Code copy button appears on hover over a fenced code block; clicking copies text to clipboard; label changes to "Copied!" for 2 seconds
- [ ] Heading anchor `#` links appear on hover; clicking navigates to the correct fragment
- [ ] All 12 hook entries in `all.md` render correctly in the table
- [ ] Examples page renders all 8 code blocks with correct syntax highlighting
- [ ] README and CONTRIBUTING render on GitHub without broken links