### PR TITLE
docs: document author byline and main navigation menu

### DIFF
--- a/content/configuration/general.md
+++ b/content/configuration/general.md
@@ -5,6 +5,7 @@ date: 2026-01-16T08:00:00.000+0700
 
 * [Activate the contact form](#activate-the-contact-form)
 * [Logo](#logo)
+* [Main navigation menu](#main-navigation-menu)
 * [Localize date format](#localize-date-format)
 * [Show taxonomies on pages](#show-taxonomies-on-pages)
 * [Show or hide dates on pages](#show-or-hide-dates-on-pages)
@@ -31,6 +32,36 @@ You can replace the title of your site in the top left corner of each page with 
 [params]
 site_logo = "img/logo.svg"
 ```
+
+### Main navigation menu
+
+The navigation shown in the header (the hero area at the top of every page) is built from Hugo's `main` menu. Define entries for it in your site configuration and they appear next to the social links.
+
+```toml
+[menus]
+[[menus.main]]
+name = "About"
+url = "/about/"
+weight = 10
+
+[[menus.main]]
+name = "Posts"
+url = "/posts/"
+weight = 20
+```
+
+Entries are ordered by their `weight`, lowest first. `url` can point to an internal section or page (for example `/about/`) or to an external address.
+
+You can also add a single page to the menu from its own front matter instead of listing it in the configuration:
+
+```yaml
+---
+title: About
+menus: main
+---
+```
+
+For nested entries, menu parameters, and other options, see Hugo's [menu templates documentation](https://gohugo.io/templates/menu-templates/).
 
 ### Localize date format
 

--- a/content/content/general.md
+++ b/content/content/general.md
@@ -3,8 +3,46 @@ title: General
 date: 2026-01-16T08:00:00.000+0700
 ---
 
+* [Author](#author)
 * [Read more link](#read-more-link)
 * [Show Reading Time and Word Count](#show-reading-time-and-word-count)
+
+### Author
+
+Add an author to a page by setting the `author` key in its front matter. The author is shown below the title on single pages and on image summary cards.
+
+```yaml
+---
+title: My First Post
+author: Jane Doe
+---
+```
+
+To set a default author for the whole site, add `author` to your site parameters. Page front matter overrides the site default.
+
+```toml
+[params]
+author = "Jane Doe"
+```
+
+You can credit more than one author by providing a list. The names are joined with commas.
+
+```yaml
+---
+title: A Collaborative Post
+author:
+  - Jane Doe
+  - John Smith
+---
+```
+
+Author names are rendered as Markdown, so you can link to a profile:
+
+```yaml
+author: "[Jane Doe](https://example.com/jane)"
+```
+
+A publication date is added with Hugo's standard `date` front matter key. See [Show or hide dates on pages](/configuration/general/#show-or-hide-dates-on-pages) for controlling whether dates appear, and [Localize date format](/configuration/general/#localize-date-format) for changing the format.
 
 ### Read more link
 


### PR DESCRIPTION
## Summary

Documents two of the recurring "how do I" basics from gohugo-ananke/documentation#8 that were not yet covered:

- **Author** (Content → General): the `author` front matter key, the site-wide `params.author` default, multiple authors as a list, and Markdown-formatted author names. Verified that Ananke renders these as a byline on single pages and on image summary cards.
- **Main navigation menu** (General Configuration): configuring Hugo's `main` menu (and the per-page `menus` front matter) to populate the header navigation that appears in the hero area.

## Status of the other items in #8

For context, the remaining points from that issue are already covered:

- *Date on a post* — [Show or hide dates on pages](/configuration/general/) and [Localize date format](/configuration/general/).
- *Smaller image next to the post title* — `featured_image` ([Hero section](/customisation/hero-section/)) plus [Show images on list page cards](/configuration/general/).
- *Tags and categories on posts* — documented via the taxonomy-links section / `show_categories` (PR #18).

## Verification

- Built a test site against the local theme and confirmed:
  - `author` renders as a byline for a single author, a list of authors (joined with commas), and falls back to the site `author` param; Markdown links in author names render inline.
  - `[menus.main]` config entries and a per-page `menus: main` front matter both add links to the header navigation.
- `markdownlint-cli2` introduces no new findings (both files carry the same pre-existing MD001 heading-level style as their existing sections).

Refs #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)